### PR TITLE
Add multiple-repo support

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -2,7 +2,9 @@
 	"type": "github",
 	"secret": "asdf",
 	"server": "irc.efnet.org",
-	"channel": "#bottest",
+	"channels": {
+		"#bottest": "test/nope"
+	}
 	"nick": "webhookbot",
 	"opts": {
 		"port": 6697,

--- a/config.json.example
+++ b/config.json.example
@@ -4,7 +4,7 @@
 	"server": "irc.efnet.org",
 	"channels": {
 		"#bottest": "test/nope"
-	}
+	},
 	"nick": "webhookbot",
 	"opts": {
 		"port": 6697,

--- a/handlers/gitea.js
+++ b/handlers/gitea.js
@@ -6,6 +6,10 @@ exports.use = function(conf) {
 	colors = conf.colors;
 }
 
-exports.push = function(bot,body) {
-	bot.say(config.channel,colors.wrap("dark_blue",body.pusher.full_name)+" pushed "+colors.codes.gray+body.commits.length+" commit"+(body.commits.length!=1 ? "s" : "")+colors.codes.reset+(body.ref.startsWith("refs/heads/") ? " to "+colors.wrap("magenta",body.ref.replace("refs/heads/","")) : "")+". ("+(body.commits.map(x => x.message.split('\n')[0]).join(", "))+")");
+function getPrefix(body) {
+	return colors.wrap("light_blue","[")+colors.wrap("light_gray",body.repository.full_name)+colors.wrap("light_blue","]")+" ";
+}
+
+exports.push = function(channel,bot,body) {
+	bot.say(channel,getPrefix(body)+colors.wrap("dark_blue",body.pusher.full_name)+" pushed "+colors.codes.gray+body.commits.length+" commit"+(body.commits.length!=1 ? "s" : "")+colors.codes.reset+(body.ref.startsWith("refs/heads/") ? " to "+colors.wrap("magenta",body.ref.replace("refs/heads/","")) : "")+". ("+(body.commits.map(x => x.message.split('\n')[0]).join(", "))+")");
 }

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const util = require("./util");
 const irc = require("irc-upd");
 config.colors = irc.colors; // why require handlers to require("irc-upd") if we can just pass them the colors through the config?
 util.use(config);
-var opts = {channels:[config.channel]};
+var opts = {channels:Object.keys(config.channels)};
 opts = Object.assign(opts,config.opts);
 var bot = new irc.Client(config.server,config.nick,opts);
 var app = require("express")();

--- a/util.js
+++ b/util.js
@@ -1,3 +1,4 @@
+const log = require("./log").log;
 const crypto = require("crypto");
 var configured = false;
 var config = {};
@@ -26,12 +27,21 @@ exports.matchSecret = function(req,secret) {
 exports.on = function(event,body,bot) {
 	if (!configured) return false;
 	if (handlers[config.type] === undefined) {
-		console.log("error: No handlers implemented for " + config.type);
+		log("error: No handlers implemented for " + config.type);
 		return false;
 	}
 	if (handlers[config.type][event] === undefined) {
-		console.log("error: No " + event + " handler implemented for " + config.type);
+		log("error: No " + event + " handler implemented for " + config.type);
 		return false;
 	}
-	handlers[config.type][event](bot,body);
+	var channel = null;
+	for (var pchannel in config.channels) {
+		if (body.repository.full_name.match(config.channels[pchannel])!==null) {
+			channel = pchannel;
+		}
+	}
+	if (channel===null) {
+		log("error: No channel defined for repo "+body.full_name);
+	}
+	handlers[config.type][event](channel,bot,body);
 }


### PR DESCRIPTION
For one-and-done bots hosting multiple repos. Checks channels against configured regexen to decide what channel gets what. One channel can be configured to do multiple repos, but one repo cannot be configured to be in multiple channels.

 - [X] Change channel configuration style to accept `"#channel": "repo/regexen"`
 - [X] Make the bot join all configured channels
 - [X] Make `util.on` use regexen to determine channel
 - [X] Make all current handlers up-to-date